### PR TITLE
drop `fix` expression

### DIFF
--- a/rep_lang_concrete_syntax/src/parse.rs
+++ b/rep_lang_concrete_syntax/src/parse.rs
@@ -92,14 +92,11 @@ where
     let if_ = (res_str("if"), expr(), expr(), expr())
         .map(|t| Expr::If(Box::new(t.1), Box::new(t.2), Box::new(t.3)));
 
-    let fix = (res_str("fix"), expr()).map(|t| Expr::Fix(Box::new(t.1)));
-
     let parenthesized = choice((
         attempt(lam),
         attempt(let_),
         attempt(list),
         attempt(if_),
-        attempt(fix),
         app,
     ));
 
@@ -226,8 +223,8 @@ where
 
 pub fn reserved() -> Vec<String> {
     [
-        "let", "lam", "fix", "true", "false", "if", "null", "map", "foldl", "pair", "fst", "snd",
-        "cons", "defn", "list", "nil",
+        "let", "lam", "true", "false", "if", "null", "map", "foldl", "pair", "fst", "snd", "cons",
+        "defn", "list", "nil",
     ]
     .iter()
     .map(|x| x.to_string())

--- a/rep_lang_concrete_syntax/src/pretty.rs
+++ b/rep_lang_concrete_syntax/src/pretty.rs
@@ -47,7 +47,6 @@ pub fn ppr_expr(expr: &Expr) -> RcDoc<()> {
             let docs = vec![RcDoc::text("if"), tst_, thn_, els_];
             parens(RcDoc::intersperse(docs, sp!()))
         }
-        Fix(x) => parens(RcDoc::text("fix ").append(ppr_expr(x))),
         Prim(op) => ppr_primop(op),
     }
 }

--- a/rep_lang_concrete_syntax/src/test/parse_pretty.rs
+++ b/rep_lang_concrete_syntax/src/test/parse_pretty.rs
@@ -39,9 +39,6 @@ pub mod parse_unit {
     fn e2() -> Expr {
         App(Box::new(e1()), Box::new(e1()))
     }
-    fn e3() -> Expr {
-        Fix(Box::new(e0()))
-    }
     fn e4() -> Expr {
         If(Box::new(e0()), Box::new(e0()), Box::new(e0()))
     }
@@ -50,13 +47,6 @@ pub mod parse_unit {
     }
     fn e6() -> Expr {
         Let(Name("v".to_string()), Box::new(e0()), Box::new(e0()))
-    }
-    fn _e7() -> Expr {
-        If(
-            Box::new(Lit(Lit::LBool(true))),
-            Box::new(e2()),
-            Box::new(e3()),
-        )
     }
 
     #[test]
@@ -72,11 +62,6 @@ pub mod parse_unit {
     #[test]
     fn ex2() {
         check_parse_expr!("((lam [x] x) (lam [x] x))", e2());
-    }
-
-    #[test]
-    fn ex3() {
-        check_parse_expr!("(fix x)", e3());
     }
 
     #[test]

--- a/rep_lang_core/src/abstract_syntax.rs
+++ b/rep_lang_core/src/abstract_syntax.rs
@@ -9,7 +9,6 @@ pub enum Expr {
     Let(Name, Box<Expr>, Box<Expr>),
     Lit(Lit),
     If(Box<Expr>, Box<Expr>, Box<Expr>),
-    Fix(Box<Expr>),
     Prim(PrimOp),
 }
 

--- a/rep_lang_core/src/test_helpers/abstract_syntax.rs
+++ b/rep_lang_core/src/test_helpers/abstract_syntax.rs
@@ -53,11 +53,6 @@ impl Arbitrary for Expr {
                 let elss = single_shrinker(*els.clone()).chain(els.shrink().map(|v| *v));
                 Box::new(pairs.chain(tsts).chain(thns).chain(elss))
             }
-            Expr::Fix(bd) => {
-                let chain = bd.shrink().map(Expr::Fix);
-                let bds = single_shrinker(*bd.clone()).chain(bd.shrink().map(|v| *v));
-                Box::new(chain.chain(bds))
-            }
             Expr::Var(_) | Expr::Lit(_) | Expr::Prim(_) => empty_shrinker(),
         }
     }
@@ -74,7 +69,7 @@ impl Arbitrary for Expr {
 // parameter as we recur, and terminating when it hits a bound.
 #[allow(dead_code)]
 pub fn gen_expr<G: Gen>(g: &mut G, size: usize, reserved: &[String]) -> Expr {
-    let upper_bound = if size < 1 { 3 } else { 8 };
+    let upper_bound = if size < 1 { 3 } else { 7 };
     match g.gen_range(0, upper_bound) {
         0 => Expr::Var(arbitrary_name(g, reserved)),
         1 => Expr::Lit(arbitrary_lit(g)),
@@ -100,10 +95,6 @@ pub fn gen_expr<G: Gen>(g: &mut G, size: usize, reserved: &[String]) -> Expr {
             let thn = gen_expr(g, size / 3, reserved);
             let els = gen_expr(g, size / 3, reserved);
             Expr::If(Box::new(tst), Box::new(thn), Box::new(els))
-        }
-        7 => {
-            let bd = gen_expr(g, size * 5 / 6, reserved);
-            Expr::Fix(Box::new(bd))
         }
         _ => panic!("impossible: gen_expr: gen out of bounds"),
     }

--- a/rep_lang_runtime/src/eval.rs
+++ b/rep_lang_runtime/src/eval.rs
@@ -226,12 +226,6 @@ pub fn eval_(env: &TermEnv, es: &mut EvalState, expr: &Expr) -> Value {
                 }
                 _ => panic!("impossible: non-closure in function position of app"),
             },
-
-            Expr::Fix(e) => eval_(
-                env,
-                es,
-                &Expr::App(e.clone(), Box::new(Expr::Fix(e.clone()))),
-            ),
         },
     }
 }

--- a/rep_lang_runtime/src/infer.rs
+++ b/rep_lang_runtime/src/infer.rs
@@ -218,13 +218,6 @@ fn infer(
             csts_e.append(&mut csts_bd);
             Ok((t_bd, csts_e))
         }
-        Expr::Fix(bd) => {
-            let (t_bd, mut csts_bd) = infer(env, is, bd)?;
-            let tv = is.fresh();
-            let cst = Constraint(t_bd, Type::TArr(Box::new(tv.clone()), Box::new(tv.clone())));
-            csts_bd.push(cst);
-            Ok((tv, csts_bd))
-        }
         Expr::Prim(op) => {
             // TODO figure out if this is borked. `poly` takes the approach of
             // wrapping primop application, whereas I allow primops to be first


### PR DESCRIPTION
we do not want arbitrary recursion in the language, and I am also not
sure how to implement `fix` (which requires substantial laziness) in
strict Rust.

closes #17.